### PR TITLE
Implement device as usbhid instead of serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ pdu = powerwalker.PDU("/dev/ttyUSB0")
 ats = powerwalker.ATS("/dev/ttyUSB1")
 ```
 
+There's a chance that your device is not being recognized as usbserial. Therefore, you have to instantiate as usbhid device:
+
+```py
+import powerwalker
+
+pdu = powerwalker.PDU("/dev/hidraw0", usbhid=True)
+ats = powerwalker.ATS("/dev/hidraw1", usbhid=True)
+```
+
+
 # PowerWalker PDU RC-16A IEC
 ![PowerWalker PDU RC-16A IEC front](media/powerwalker_pdu_rc-16a_front.jpg)
 ![PowerWalker PDU RC-16A IEC back](media/powerwalker_pdu_rc-16a_back.jpg)

--- a/powerwalker/ats.py
+++ b/powerwalker/ats.py
@@ -2,9 +2,10 @@ from .pw_common import Powerwalker
 
 
 class ATS(Powerwalker):
-  def __init__(self, port):
+  def __init__(self, port, usbhid=False):
     self.port = port
     self.serial = None
+    self.usbhid = usbhid
     self.connect()
 
 

--- a/powerwalker/pdu.py
+++ b/powerwalker/pdu.py
@@ -2,9 +2,10 @@ from .pw_common import Powerwalker
 
 
 class PDU(Powerwalker):
-  def __init__(self, port):
+  def __init__(self, port, usbhid=False):
     self.port = port
     self.serial = None
+    self.usbhid = usbhid
     self.connect()
 
 


### PR DESCRIPTION
Hello,

First of all, thanks for the amazing work here.

For some reason, my PowerWalker ATS is not recognized when plugged directly through USB. Your library works fine if I use a max232 connected to powerwalker ATS serial and then usb-serial dongle to my computer.

Therefore, I started doing some research and was successful using the usbhid directly on a file descriptor.

Let me know if you want any changes.